### PR TITLE
Group user_id and email calls

### DIFF
--- a/src/main/java/com/mparticle/kits/TaplyticsKit.java
+++ b/src/main/java/com/mparticle/kits/TaplyticsKit.java
@@ -147,6 +147,11 @@ public class TaplyticsKit extends KitIntegration
     }
 
     @Override
+    public void setUserIdentity(IdentityType identityType, String s) {
+        // no-op
+    }
+
+    @Override
     public void removeUserIdentity(MParticle.IdentityType identityType) {
         setUserIdentity(identityType, null);
     }
@@ -155,11 +160,6 @@ public class TaplyticsKit extends KitIntegration
     @Override
     public void removeUserAttribute(String attribute) {
         setUserAttribute(attribute, null);
-    }
-
-    @Override
-    public void setUserIdentity(IdentityType identityType, String s) {
-        // no-op
     }
 
     @Override

--- a/src/main/java/com/mparticle/kits/TaplyticsKit.java
+++ b/src/main/java/com/mparticle/kits/TaplyticsKit.java
@@ -147,19 +147,6 @@ public class TaplyticsKit extends KitIntegration
     }
 
     @Override
-    public void setUserIdentity(MParticle.IdentityType identityType, String identity) {
-        switch (identityType) {
-            case CustomerId: {
-                setUserAttribute(USER_ID, identity);
-                break;
-            }
-            case Email: {
-                setUserAttribute(EMAIL, identity);
-            }
-        }
-    }
-
-    @Override
     public void removeUserIdentity(MParticle.IdentityType identityType) {
         setUserIdentity(identityType, null);
     }
@@ -168,6 +155,11 @@ public class TaplyticsKit extends KitIntegration
     @Override
     public void removeUserAttribute(String attribute) {
         setUserAttribute(attribute, null);
+    }
+
+    @Override
+    public void setUserIdentity(IdentityType identityType, String s) {
+        // no-op
     }
 
     @Override


### PR DESCRIPTION
## Summary

Remove logic from `setUserIdentity` and use `onIdentifyCompleted` and `onLoginCompleted` so Taplytics calls to set `user_id` and `email` are grouped in one call.