### PR TITLE
feat: Add flag to initialize SDK on Session Start

### DIFF
--- a/src/test/java/com/mparticle/kits/KitTests.java
+++ b/src/test/java/com/mparticle/kits/KitTests.java
@@ -3,20 +3,32 @@ package com.mparticle.kits;
 
 import android.content.Context;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import com.mparticle.internal.KitManager;
 
 public class KitTests {
 
     private KitIntegration getKit() {
         return new TaplyticsKit();
+    }
+
+    @Before
+    public void testDefaultStaticFields() {
+        //make sure we are not carrying over any static settings in between tests
+        assertFalse(TaplyticsKit.started);
+        assertFalse(TaplyticsKit.delayInitializationUntilSessionStart);
     }
 
     @Test
@@ -41,6 +53,7 @@ public class KitTests {
             e = ex;
         }
         assertNotNull(e);
+        reset();
     }
 
     @Test
@@ -54,5 +67,90 @@ public class KitTests {
             }
         }
         fail(className + " not found as a known integration.");
+        reset();
+    }
+
+    @Test
+    public void testInitializationNoSessionStartDelayFlag() {
+        MockTaplyticsKit taplyticsKit = new MockTaplyticsKit();
+
+        //starts without SessionStart delay flag
+        taplyticsKit.onKitCreate(Collections.emptyMap(), Mockito.mock(Context.class));
+        assertTrue(taplyticsKit.startCalled);
+        assertFalse(TaplyticsKit.delayInitializationUntilSessionStart);
+        assertTrue(TaplyticsKit.started);
+
+        //make sure there are no duplicate starts
+        taplyticsKit.startCalled = false;
+        taplyticsKit.onKitCreate(Collections.emptyMap(), Mockito.mock(Context.class));
+        assertFalse(taplyticsKit.startCalled);
+        assertTrue(TaplyticsKit.started);
+
+        //alse make sure there is no duplicate start in onSessionStart
+        taplyticsKit.startCalled = false;
+        taplyticsKit.onSessionStart();
+        assertFalse(taplyticsKit.startCalled);
+        assertTrue(TaplyticsKit.started);
+
+        reset();
+    }
+
+    @Test
+    public void testInitializationWithSessionStartDelayFlag() {
+        MockTaplyticsKit taplyticsKit = new MockTaplyticsKit();
+        TaplyticsKit.started = false;
+        TaplyticsKit.delayInitializationUntilSessionStart = false;
+
+        //doesn't start in onCreate with SessionStart delay flag
+        taplyticsKit = new MockTaplyticsKit();
+        MockTaplyticsKit.delayInitializationUntilSessionStart = true;
+        taplyticsKit.onKitCreate(Collections.emptyMap(), Mockito.mock(Context.class));
+        assertFalse(taplyticsKit.startCalled);
+        assertTrue(TaplyticsKit.delayInitializationUntilSessionStart);
+        assertFalse(TaplyticsKit.started);
+
+        //does start in onSessionStart with SessionStart delay flag
+        taplyticsKit.onSessionStart();
+
+        assertTrue(taplyticsKit.startCalled);
+        assertTrue(TaplyticsKit.delayInitializationUntilSessionStart);
+        assertTrue(TaplyticsKit.started);
+
+        //make sure there are no duplicate starts
+        taplyticsKit.startCalled = false;
+        taplyticsKit.onSessionStart();
+        assertFalse(taplyticsKit.startCalled);
+        assertTrue(TaplyticsKit.started);
+
+        //als0 make sure there is no duplicate start in onKitCreate (situation shouldn't ever happen anyway)
+        taplyticsKit.startCalled = false;
+        taplyticsKit.onKitCreate(Collections.emptyMap(), Mockito.mock(Context.class));
+        assertFalse(taplyticsKit.startCalled);
+        assertTrue(TaplyticsKit.started);
+
+        reset();
+    }
+
+    private void reset() {
+        TaplyticsKit.started = false;
+        TaplyticsKit.delayInitializationUntilSessionStart = false;
+    }
+
+    class MockTaplyticsKit extends TaplyticsKit {
+        boolean startCalled = false;
+
+        public MockTaplyticsKit() {
+            KitConfiguration mockConfiguration = Mockito.mock(KitConfiguration.class);
+            KitManagerImpl mockKitManager = Mockito.mock(KitManagerImpl.class);
+            Mockito.when(mockKitManager.getContext()).thenReturn(Mockito.mock(Context.class));
+            Mockito.when(mockConfiguration.getSettings()).thenReturn(Collections.emptyMap());
+            setKitManager(mockKitManager);
+            setConfiguration(mockConfiguration);
+        }
+
+        @Override
+        protected void startTaplytics(Map<String, String> settings, Context context) {
+            startCalled = true;
+        }
     }
 }


### PR DESCRIPTION
# Summary

Client is having an issue where Taplytics is starting Sessions (Taplytics Session, no mp) when their app is being woken up in the background. I have gathered that Taplytics does not have a surface to configure any sort of Session logic that would alleviate this, currently when the Taplytics SDK is initialized, they will start an internal Session.

Since we suggest that MParticle is initialized in Application#onCreate(), but _we_ will not start a session until some sort of interaction on top of the actual initialization is received, I think it is reasonable for us to provide a workaround to avoid underlying Kit's SDKs from starting excessive sessions. 

In this PR the (ad-hoc) fix is to include a static boolean flag, `delayInitializationUntilSessionStart`, which, when set to `true`, will start the Taplytics SDK in the `onSessionStart()` method instead of in the `onKitCreate()` method. There are a few _potential_ edge cases that I have deemed to be moot:

1) What if the client has the option enabled and an event gets logged to the Taplytics kit, is it possible the underlying SDK may not be initialized yet?

- no. If and event is logged, User opt-out status is toggled, userAttribute is updated, etc, then the core MParticle SDK will have already started a Session which (synchronously) will initialize the Taplytics SDK before the event arrives at the kit

2) Shouldn't this option be settable from the remote config/MParticle Web App?

- due to the current code freeze, we are unable to update out Kit configuration settings without extenuating circumstances, so the local static flag is the best way to get this option up and running right now. After the code freeze expires in Q1, we will consider making this option remote-configurable


example usage:
```
fun onCreate() {
    TaplyticsKit.delayInitializationUntilSessionStart = true
    MParticle.start(options)
}
```